### PR TITLE
Change switch statement in Version task to use ToLower on argument

### DIFF
--- a/generators/cakeplus/templates/build.cake
+++ b/generators/cakeplus/templates/build.cake
@@ -11,7 +11,7 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
-var versionType = Argument("VersionType", "Patch");
+var versionType = Argument("VersionType", "patch");
 var artifacts = MakeAbsolute(Directory(Argument("artifactPath", "./artifacts")));
 
 GitVersion versionInfo = null;

--- a/generators/cakeplus/templates/build.cake
+++ b/generators/cakeplus/templates/build.cake
@@ -50,7 +50,7 @@ Task("Version")
 		major = assertedVersions.Major;
 		minor = assertedVersions.Minor;
 		patch = assertedVersions.Patch;
-		switch (versionType)
+		switch (versionType.ToLower())
 		{
 			case "patch":
 				patch += 1; break;


### PR DESCRIPTION
The build.cake template passes a default version argument of Patch.
The switch statement specifies cases in lower case so by default the script falls through the switch statement and doesn't change the default 0.1.0 tag.
This throws "Error: Tag already exists"
To fix this I've added .ToLower() on the versionType variable in the switch.